### PR TITLE
feat: Add Home link to top navigation bar

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,7 +83,8 @@ export const Header = forwardRef<
       <div className="flex items-center gap-5">
         <nav className="hidden md:block">
           <ul role="list" className="flex items-center gap-8">
-          <TopLevelNavItem href="https://whitepaper_ar-io.arweave.net" target='_blank'>Whitepaper</TopLevelNavItem>
+            <TopLevelNavItem href="/">Home</TopLevelNavItem>
+            <TopLevelNavItem href="https://whitepaper_ar-io.arweave.net" target='_blank'>Whitepaper</TopLevelNavItem>
             <TopLevelNavItem href="/learn/introduction">Learn</TopLevelNavItem>
             <TopLevelNavItem href="/build/ar-io-sdk">Build</TopLevelNavItem>
             <TopLevelNavItem href="/community-resources">


### PR DESCRIPTION
# Add Home link to top navigation bar

## Description
Added a "Home" link to the top navigation bar to improve navigation accessibility. While the ar.io icon in the top left already functions as a home button, this addition provides a more explicit and user-friendly navigation option.

## Changes
- Added "Home" as the first item in the top navigation menu
- Maintains consistent styling with existing navigation items using `TopLevelNavItem` component
- Preserves existing functionality of logo link

## Screenshots
<img width="1798" alt="Screenshot 2024-12-17 at 07 10 20" src="https://github.com/user-attachments/assets/2d6dcae6-88c5-4920-be6f-111dd6b4b560" />