### PR TITLE
Permaweb Glossary

### DIFF
--- a/src/app/glossary/page.mdx
+++ b/src/app/glossary/page.mdx
@@ -176,5 +176,5 @@ The Wayfinder protocol provides applications with a pattern for dynamically swit
 
 ## Permaweb Glossary
 
-For a more comprehensive glossary of terms used in the permaweb, try the [Permaweb Glossary](https://glossary_tiny4vr.permagate.io/). Or use it below:
+For a more comprehensive glossary of terms used in the permaweb, try the [Permaweb Glossary](https://glossary.permagate.io/). Or use it below:
 <iframe src="https://glossary.permagate.io/?hide-header=true&transparent=true" width="100%" height="600px"></iframe>

--- a/src/app/glossary/page.mdx
+++ b/src/app/glossary/page.mdx
@@ -177,4 +177,4 @@ The Wayfinder protocol provides applications with a pattern for dynamically swit
 ## Permaweb Glossary
 
 For a more comprehensive glossary of terms used in the permaweb, try the [Permaweb Glossary](https://glossary_tiny4vr.permagate.io/). Or use it below:
-<iframe src="https://glossary_tiny4vr.permagate.io/?hide-header=true&transparent=true" width="100%" height="600px"></iframe>
+<iframe src="https://glossary.permagate.io/?hide-header=true&transparent=true" width="100%" height="600px"></iframe>

--- a/src/app/glossary/page.mdx
+++ b/src/app/glossary/page.mdx
@@ -4,7 +4,7 @@ import {HeroPattern} from "@/components/HeroPattern"
 
 # Glossary
 
-Many novel terms and acronyms are used by the Arweave ecosystem as well as some new ones introduced by AR.IO. The list below is intended to serve as a non-exhaustive reference of those terms: 
+Many novel terms and acronyms are used by the Arweave ecosystem as well as some new ones introduced by AR.IO. The list below is intended to serve as a non-exhaustive reference of those terms. For a comprehensive glossary of permaweb-specific terminology, check out the [permaweb glossary section](#permaweb-glossary): 
 
 ## **AO Computer (AO)**: 
 
@@ -173,3 +173,8 @@ Token vaults are protocol level mechanisms used to contain staked tokens over ti
 ## **Wayfinder Protocol**:
 
 The Wayfinder protocol provides applications with a pattern for dynamically switching / routing between network gateways. It also allows for abstraction of top level domain names from Arweave data and verifies the responses from AR.IO Gateways. It forms the basis of the ar:// schema, so users can seamlessly access ArNS names, Arweave base layer transactions, and bundled data items without the user providing a top-level domain.  
+
+## Permaweb Glossary
+
+For a more comprehensive glossary of terms used in the permaweb, try the [Permaweb Glossary](https://glossary_tiny4vr.permagate.io/). Or use it below:
+<iframe src="https://glossary_tiny4vr.permagate.io/?hide-header=true&transparent=true" width="100%" height="600px"></iframe>


### PR DESCRIPTION
# Add Permaweb Glossary Integration

This PR adds a new section to the glossary page that embeds the Permaweb Glossary from permagate.io. The changes include:

1. Added a reference to the permaweb glossary in the introduction
2. Added a new "Permaweb Glossary" section with an embedded iframe

The embedded glossary provides users with access to a comprehensive collection of permaweb-specific terminology, enhancing the documentation's completeness.