### PR TITLE
feat(sdk): add raw HTML examples to SDK quickstart sections

### DIFF
--- a/content/sdks/ar-io-sdk/index.mdx
+++ b/content/sdks/ar-io-sdk/index.mdx
@@ -12,7 +12,7 @@ The AR.IO SDK provides comprehensive tools for interacting with the AR.IO Networ
 
 ## Quick Start
 
-<Tabs items={['Node.js', 'Web (Browser)']}>
+<Tabs items={['Node.js', 'Web (React)', 'Web (HTML)']}>
   <Tab value="Node.js">
     <Steps>
       <Step>
@@ -26,16 +26,16 @@ The AR.IO SDK provides comprehensive tools for interacting with the AR.IO Networ
         ### Use the SDK
 
         ```javascript
-        import { ARIO } from '@ar.io/sdk';
+        import { ARIO } from '@ar.io/sdk/node';
 
         // Connect to mainnet
         const ario = ARIO.mainnet();
 
-        // Get gateway information
-        const gateways = await ario.getGateways();
+        // Get paginated gateway registry
+        const { items: gateways } = await ario.getGateways();
 
-        // Get ArNS records
-        const records = await ario.getArNSRecords();
+        // Get paginated ArNS registry
+        const { items: records } = await ario.getArNSRecords();
 
         console.log('Network data:', { gateways, records });
         ```
@@ -55,7 +55,7 @@ The AR.IO SDK provides comprehensive tools for interacting with the AR.IO Networ
         ### Install polyfills (required for web environments)
 
         <Callout type="warn">
-        Crypto polyfills are required for web environments due to the use of `crypto`, `buffer` and `process` types in the SDK's dependencies.
+        Polyfills are required for React web environments due to the use of `crypto`, `buffer` and `process` types in the SDK's dependencies.
         </Callout>
 
         ```npm
@@ -86,21 +86,69 @@ The AR.IO SDK provides comprehensive tools for interacting with the AR.IO Networ
         ### Use the SDK
 
         ```javascript
-        import { ARIO } from '@ar.io/sdk';
+        import { ARIO } from '@ar.io/sdk/web';
 
         // Connect to mainnet
         const ario = ARIO.mainnet();
 
-        // Get gateway information
-        const gateways = await ario.getGateways();
+        // Get paginated gateway registry
+        const { items: gateways } = await ario.getGateways();
 
-        // Get ArNS records
-        const records = await ario.getArNSRecords();
+        // Get paginated ArNS registry
+        const { items: records } = await ario.getArNSRecords();
 
         console.log('Network data:', { gateways, records });
         ```
       </Step>
     </Steps>
+  </Tab>
+  <Tab value="Raw HTML">
+    ```html
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>AR.IO SDK Example</title>
+        <script type="module">
+            // Polyfills are included in the minimized web bundle, so not necessary to import directly
+            import { ARIO } from 'https://unpkg.com/@ar.io/sdk';
+            
+            // Connect to mainnet
+            const ario = ARIO.mainnet();
+            
+            // Function to load AR.IO data
+            async function loadArioData() {
+                try {
+                    // Get gateway information
+                    const { items: gateways } = await ario.getGateways();
+                    
+                    // Get ArNS records
+                    const { items: records } = await ario.getArNSRecords();
+                    
+                    // Display results
+                    document.getElementById('results').innerHTML = `
+                        <h3>Gateways: ${Object.keys(gateways).length}</h3>
+                        <h3>ArNS Records: ${Object.keys(records).length}</h3>
+                        <pre>${JSON.stringify({ gateways, records }, null, 2)}</pre>
+                    `;
+                } catch (error) {
+                    document.getElementById('results').innerHTML = `
+                        <p style="color: red;">Error: ${error.message}</p>
+                    `;
+                }
+            }
+            
+            // Load data when page loads
+            window.addEventListener('load', loadArioData);
+        </script>
+    </head>
+    <body>
+        <h1>AR.IO SDK Example</h1>
+        <div id="results">
+            <p>Loading AR.IO data...</p>
+        </div>
+    </body>
+    </html>
+    ```
   </Tab>
 </Tabs>
 

--- a/content/sdks/turbo-sdk/index.mdx
+++ b/content/sdks/turbo-sdk/index.mdx
@@ -12,7 +12,7 @@ The Turbo SDK provides a high-level interface for uploading data to Arweave thro
 
 ## Quick Start
 
-<Tabs items={['Node.js', 'Web (Browser)']}>
+<Tabs items={['Node.js', 'Web (React)', 'Web (HTML)']}>
   <Tab value="Node.js">
     <Steps>
       <Step>
@@ -43,7 +43,7 @@ The Turbo SDK provides a high-level interface for uploading data to Arweave thro
       </Step>
     </Steps>
   </Tab>
-  <Tab value="Web (Browser)">
+  <Tab value="Web (React)">
     <Steps>
       <Step>
         ### Install the SDK
@@ -56,7 +56,7 @@ The Turbo SDK provides a high-level interface for uploading data to Arweave thro
         ### Install polyfills (required for web environments)
 
         <Callout type="warn">
-        Crypto polyfills are required for web environments due to the use of `crypto`, `buffer` and `process` types in the SDK's dependencies.
+        Polyfills are required for React web environments due to the use of `crypto`, `buffer` and `process` types in the SDK's dependencies.
         </Callout>
 
         ```npm
@@ -105,6 +105,90 @@ The Turbo SDK provides a high-level interface for uploading data to Arweave thro
         ```
       </Step>
     </Steps>
+  </Tab>
+  <Tab value="Web (HTML)">
+    ```html
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Turbo SDK Upload Example</title>
+        <script type="module">
+            // Polyfills are included in the minimized web bundle, so not necessary to import directly
+            import { TurboFactory } from 'https://unpkg.com/@ardrive/turbo-sdk@latest';
+            
+            // Function to handle file upload
+            async function uploadFile() {
+                const fileInput = document.getElementById('fileInput');
+                const file = fileInput.files[0];
+                const privateKeyInput = document.getElementById('privateKey');
+                
+                if (!file) {
+                    alert('Please select a file');
+                    return;
+                }
+                
+                if (!privateKeyInput.value) {
+                    alert('Please enter your private key');
+                    return;
+                }
+                
+                try {
+                    // Show loading state
+                    document.getElementById('status').textContent = 'Uploading...';
+                    
+                    // Create authenticated client
+                    const turbo = TurboFactory.authenticated({ 
+                        privateKey: privateKeyInput.value 
+                    });
+                    
+                    // Upload file
+                    const result = await turbo.uploadFile({
+                        fileStreamFactory: () => file.stream(),
+                        fileSizeFactory: () => file.size,
+                    });
+                    
+                    // Show success
+                    document.getElementById('status').innerHTML = `
+                        <p style="color: green;">Upload successful!</p>
+                        <p>Transaction ID: ${result.id}</p>
+                        <p>Data Item ID: ${result.dataItemId}</p>
+                    `;
+                } catch (error) {
+                    document.getElementById('status').innerHTML = `
+                        <p style="color: red;">Error: ${error.message}</p>
+                    `;
+                }
+            }
+            
+            // Add click handler
+            window.addEventListener('load', () => {
+                document.getElementById('uploadBtn').addEventListener('click', uploadFile);
+            });
+        </script>
+    </head>
+    <body>
+        <h1>Turbo SDK Upload Example</h1>
+        
+        <div>
+            <label>
+                Private Key (JWK):
+                <input type="password" id="privateKey" style="width: 300px;" />
+            </label>
+        </div>
+        
+        <div style="margin-top: 10px;">
+            <label>
+                Select File:
+                <input type="file" id="fileInput" />
+            </label>
+        </div>
+        
+        <button id="uploadBtn" style="margin-top: 10px;">Upload to Arweave</button>
+        
+        <div id="status" style="margin-top: 20px;"></div>
+    </body>
+    </html>
+    ```
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
- Add Raw HTML tab to both AR.IO SDK and Turbo SDK quickstarts
- AR.IO SDK example shows loading gateway and ArNS data
- Turbo SDK example demonstrates file upload with web bundle
- Uses unpkg CDN for direct browser usage without build tools

🤖 Generated with [Claude Code](https://claude.ai/code)