### PR TITLE
Fix MDX link handling for public assets (llms-full.txt)

### DIFF
--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -21,6 +21,7 @@ export default async function Page(props: {
   }
 
   const MDXContent = page.data.body;
+  const RelativeLink = createRelativeLink(source, page);
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
@@ -38,7 +39,19 @@ export default async function Page(props: {
         <MDXContent
           components={getMDXComponents({
             // this allows you to link to other pages with relative file paths
-            a: createRelativeLink(source, page),
+            a: (props) => {
+              const href = typeof props.href === "string" ? props.href : "";
+
+              // For public assets like /llms-full.txt, use a plain anchor so the browser
+              // requests the static file instead of the docs catch-all route.
+              const isPublicAsset =
+                href.startsWith("/") &&
+                /\.(?:txt|json|xml|pdf)($|[?#])/i.test(href);
+
+              if (isPublicAsset) return <a {...props} />;
+
+              return <RelativeLink {...props} />;
+            },
           })}
         />
         <PageFeedback pageUrl={page.url} />


### PR DESCRIPTION
### Problem
Clicking [llms-full.txt](/llms-full.txt) from `content/learn/(introduction)/index.mdx` works on localhost, but in production it routes through the docs catch-all and redirects back to `/learn`.

### Root cause
In `src/app/[[...slug]]/page.tsx`, MDX anchors are rendered via `a: createRelativeLink(source, page)`, which treats `/llms-full.txt` as an internal docs route. Since it isn’t a docs page, the catch-all page triggers `redirect("/learn")`.

### Fix
Wrap the MDX `a` component so absolute links ending in `.txt|.json|.xml|.pdf` render as a plain `<a>` (browser does a real request to `/public` assets). All other links continue to use `createRelativeLink` for internal/relative docs navigation.