### PR TITLE
Remove data deduplication section from ArFS docs

### DIFF
--- a/content/build/advanced/arfs/index.mdx
+++ b/content/build/advanced/arfs/index.mdx
@@ -27,10 +27,6 @@ ArFS supports public and private file permissions. Public files can be accessed 
 
 ArFS supports versioning of files, allowing users to store multiple versions of a file and access previous versions at any time. This is achieved by linking new file transactions to previous versions through the use of metadata tags.
 
-### Data Deduplication
-
-To minimize storage redundancy and costs, ArFS employs data deduplication techniques. If a user tries to store a file that already exists on the network, the protocol will simply create a new reference to the existing file instead of storing a duplicate copy.
-
 ### Search and Discovery
 
 ArFS enables users to search and discover files based on their metadata, such as file names, types, and tags. This is made possible by indexing the metadata stored within the Arweave blockchain.


### PR DESCRIPTION
Removed section on data deduplication from the documentation.