### PR TITLE
fix: resolve duplicated slugs build failure

### DIFF
--- a/content/sdks/ar-io-sdk/(advanced)/meta.json
+++ b/content/sdks/ar-io-sdk/(advanced)/meta.json
@@ -5,7 +5,7 @@
     "circuit-breaker",
     "automatic-retries",
     "generated-instruction-builders",
-    "networks"
+    "solana-networks"
   ],
   "defaultOpen": false
 }

--- a/content/sdks/ar-io-sdk/(advanced)/solana-networks.mdx
+++ b/content/sdks/ar-io-sdk/(advanced)/solana-networks.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Networks"
+title: "Solana Networks"
 description: "TypeScript/JavaScript SDK for interacting with the ar.io ecosystem"
 ---
 


### PR DESCRIPTION
## Summary
- The deploy workflow was failing with `Error: Duplicated slugs` during the Next.js production build
- Two files — `(advanced)/networks.mdx` and `(ario-contract)/networks.mdx` — both resolved to the slug `sdks/ar-io-sdk/networks` because parenthesized route group folders are stripped from URLs
- Renamed `(advanced)/networks.mdx` → `solana-networks.mdx` (with updated title and meta.json) to eliminate the collision
- Introduced in commit 49a3d304 ("chore: fix and use sdk docs generation")

## Test plan
- [x] Verified `next build` completes successfully with all 279 static pages generated
- [ ] Confirm deploy workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)