### PR TITLE
chore: update ar.io command to ensure latest ar.io SDK installed

### DIFF
--- a/content/build/run-a-gateway/manage/solana-migration.mdx
+++ b/content/build/run-a-gateway/manage/solana-migration.mdx
@@ -191,7 +191,7 @@ Complete these steps before the cutover date to ensure uninterrupted reward elig
 
     2. **Gateway registration is live on the new network:**
        ```bash
-       ar.io get-gateway -t solana \
+       npx @ar.io/sdk@latest get-gateway -t solana \
          --rpc-url https://api.mainnet-beta.solana.com \
          --core-program-id 73YoECm6NKXpVRoe5f1Q9BcP5DJGPFUjnFy6AxBE5Nvh \
          --gar-program-id 89fNiiwgpFSPHKuqfNUkgYTYjtAJAhyqHjXmgXeppGpf \


### PR DESCRIPTION
If the `ar.io/sdk` hasn't been updated it will run the command and fail with 

```bash
error: unknown option '--rpc-url'
(Did you mean --cu-url?)
```