### PR TITLE
chore: migrate from permaweb-deploy to @ar.io/deploy

### DIFF
--- a/.github/workflows/deploy-to-arweave.yaml
+++ b/.github/workflows/deploy-to-arweave.yaml
@@ -62,12 +62,11 @@ jobs:
       - name: Build Next.js application
         run: yarn build
 
-      - uses: permaweb/permaweb-deploy@v0.1.0
-        env:
-          NODE_ENV: production
+      - name: Deploy to Arweave
+        uses: ar-io/ar-io-deploy@v1
         with:
           deploy-key: ${{ secrets.DEPLOY_KEY }}
+          arns-key: ${{ secrets.ARNS_KEY }}
           arns-name: ${{ secrets.ARNS_NAME }}
-          preview: "true"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          undername: "${{ github.event_name == 'workflow_dispatch' && inputs.undername || '@' }}"
           deploy-folder: ./out

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -49,9 +49,11 @@ jobs:
       - name: Build Next.js application
         run: yarn build
 
-      - uses: permaweb/permaweb-deploy@v0.1.0
+      - name: Deploy PR preview
+        uses: ar-io/ar-io-deploy@v1
         with:
           deploy-key: ${{ secrets.DEPLOY_KEY }}
+          arns-key: ${{ secrets.ARNS_KEY }}
           arns-name: ${{ secrets.ARNS_NAME }}
           preview: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces `permaweb/permaweb-deploy@v0.1.0` with `ar-io/ar-io-deploy@v1` in both deploy workflows
- Fixes production workflow: removed erroneous `preview: "true"` flag (was causing preview behavior on prod deploys)
- Wires up the `workflow_dispatch` undername input that was previously defined but unused
- Uses the two-key model: `DEPLOY_KEY` (Arweave) for uploads, `ARNS_KEY` (Solana) for ArNS updates

## Setup required
- Add `ARNS_KEY` secret (base58 Solana key with ArNS authority)

## Test plan
- [ ] Verify `ARNS_KEY` secret is set
- [ ] Test PR preview deployment
- [ ] Test production deployment on merge to main