### PR TITLE
fix(testnet): use theme-aware Callout instead of dark-only Tip

### DIFF
--- a/content/build/testnet/funds-and-faucet.mdx
+++ b/content/build/testnet/funds-and-faucet.mdx
@@ -91,11 +91,11 @@ runs low.
 
 </Steps>
 
-<Tip title="Faucet agent skill">
-  The faucet ships an `ario-testnet-faucet` agent skill documenting the claim API and flow. Pair
-  it with the human-claims-once pattern above so your agent has funds without needing to solve the
-  OAuth gate.
-</Tip>
+<Callout type="info">
+  **Faucet agent skill.** The faucet ships an `ario-testnet-faucet` agent skill documenting the
+  claim API and flow. Pair it with the human-claims-once pattern above so your agent has funds
+  without needing to solve the OAuth gate.
+</Callout>
 
 ## Next steps
 

--- a/content/build/testnet/index.mdx
+++ b/content/build/testnet/index.mdx
@@ -137,13 +137,13 @@ Your name is live at `https://<name>.ar-io.dev`. See
 The sandbox is a natural fit for AI coding assistants and automated tests — free tokens, plain
 HTTP endpoints, and no way to spend real value or write permanent data.
 
-<Tip title="One human step: the faucet">
-  The ARIO faucet is **GitHub-gated** to prevent abuse, and the OAuth consent can't be
-  completed headlessly. The standard pattern is: a **human claims once** to the wallet address
-  your agent will use, then the agent simply **uses** the ARIO. After that, uploading, funding,
-  and buying ArNS names are all scriptable API calls. See
+<Callout type="info">
+  **One human step: the faucet.** The ARIO faucet is **GitHub-gated** to prevent abuse, and the
+  OAuth consent can't be completed headlessly. The standard pattern is: a **human claims once** to
+  the wallet address your agent will use, then the agent simply **uses** the ARIO. After that,
+  uploading, funding, and buying ArNS names are all scriptable API calls. See
   [Funds & Faucet → Agents and CI](/build/testnet/funds-and-faucet#agents-and-ci).
-</Tip>
+</Callout>
 
 This documentation is also available as machine-readable text (`/llms-full.txt`) and every page
 has an **Open in AI** action, so you can hand the full sandbox reference to your agent in one


### PR DESCRIPTION
## Problem
The two testnet pages used the `<Tip>` component, which hard-codes `bg-gray-800 text-white` (dark styling) regardless of the active theme — so in **light mode** it rendered as a jarring dark box with orange text.

## Fix
Swapped both usages to the standard, theme-aware `<Callout type="info">` used everywhere else in the docs, keeping each title as bold lead text. These were the **only** two `<Tip>` usages in the entire docs, so nothing else is affected.

- `content/build/testnet/index.mdx` — "One human step: the faucet"
- `content/build/testnet/funds-and-faucet.mdx` — "Faucet agent skill"

## Verification
- `npm run lint` ✓ (both files)
- No `<Tip>` remaining in `content/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)