### PR TITLE
docs(agents): surface machine-readable entry points for AI agents

### DIFF
--- a/content/build/agents.mdx
+++ b/content/build/agents.mdx
@@ -1,0 +1,159 @@
+---
+title: "AI Agents & LLMs"
+description: "Machine-readable entry points for building on ar.io with AI coding agents — llms.txt, SKILL.md, llms-full.txt, per-SDK llm.txt, and a free testnet sandbox to run against."
+keywords:
+  - AI agents
+  - LLM
+  - llms.txt
+  - SKILL.md
+  - llm.txt
+  - MCP
+  - Claude
+  - agent skill
+---
+
+These docs are built to be consumed by **AI coding agents**, not just read by humans. Everything
+below is a plain-text file you can fetch, paste, or point an agent at — no scraping required.
+
+<Callout type="info">
+  **Fastest path:** point your agent at <a href="/llms.txt" target="_blank" rel="noopener noreferrer">`https://docs.ar.io/llms.txt`</a>.
+  It's a short index that links everything else, following the
+  [llmstxt.org](https://llmstxt.org) convention agents already look for.
+</Callout>
+
+## Machine-readable entry points
+
+| File | What it is | Reach for it when |
+|---|---|---|
+| <a href="/llms.txt" target="_blank" rel="noopener noreferrer">`/llms.txt`</a> | A short **index** of the documentation with links and quick facts | Discovery — the entry point |
+| <a href="/SKILL.md" target="_blank" rel="noopener noreferrer">`/SKILL.md`</a> | A **procedural agent skill**: SDK patterns, code recipes, URL conventions, constants | Generating working code |
+| <a href="/llms-full.txt" target="_blank" rel="noopener noreferrer">`/llms-full.txt`</a> | The **entire docs corpus** as one plain-text file (~1.2 MB) | Deep context, or RAG ingestion |
+| `/sdks/<sdk>/llm.txt` | **Per-SDK reference** text (see table below) | Working inside a single SDK |
+
+### `llm.txt` vs `SKILL.md` — what's the difference?
+
+They solve different problems and are meant to be used together:
+
+- **`llms.txt` / `llms-full.txt` / `llm.txt` are *reference*.** They're documentation flattened to
+  plain text so a model has the facts in context. Passive — they describe *what exists*.
+- **`SKILL.md` is *procedural*.** It follows the
+  [Agent Skills](https://code.claude.com/docs/en/skills) convention: task-oriented instructions,
+  known-good code recipes, and constants that teach an agent *how to actually build* on ar.io —
+  which SDK call to make, the correct ArNS URL shape, what to avoid.
+
+A useful rule of thumb: load **`SKILL.md`** when the agent needs to *write code*, and
+**`llms-full.txt`** when it needs to *answer questions* about the wider platform.
+
+## Per-SDK reference text
+
+Each SDK ships its own flattened reference, which is much cheaper to load than the full corpus:
+
+| SDK | Plain text |
+|---|---|
+| ar.io SDK | <a href="/sdks/ar-io-sdk/llm.txt" target="_blank" rel="noopener noreferrer">`/sdks/ar-io-sdk/llm.txt`</a> |
+| Turbo SDK | <a href="/sdks/turbo-sdk/llm.txt" target="_blank" rel="noopener noreferrer">`/sdks/turbo-sdk/llm.txt`</a> |
+| Wayfinder | <a href="/sdks/wayfinder/llm.txt" target="_blank" rel="noopener noreferrer">`/sdks/wayfinder/llm.txt`</a> |
+| ArDrive Core JS | <a href="/sdks/ardrive-core-js/llm.txt" target="_blank" rel="noopener noreferrer">`/sdks/ardrive-core-js/llm.txt`</a> |
+| CLIs (ArDrive CLI, ARIO Deploy) | <a href="/sdks/(clis)/llm.txt" target="_blank" rel="noopener noreferrer">`/sdks/(clis)/llm.txt`</a> |
+
+## Give your agent somewhere safe to run
+
+Agents learn fastest by *doing*, but you don't want a agent spending real money or writing
+permanent data while it figures things out. The **[Testnet Sandbox](/build/testnet)** is built for
+exactly this:
+
+- Runs the **full ar.io stack** — upload, payment, ArNS, and gateway — on Solana **devnet**.
+- Funded by a **faucet**, so there's no real value at risk.
+- **Nothing is permanent**: data is purged after ~3 days and never reaches mainnet Arweave.
+
+<Callout type="warning">
+  **One step needs a human.** The ARIO faucet is GitHub-gated and its OAuth consent can't be
+  completed headlessly. Have a person claim once to the wallet your agent will use — after that,
+  uploading, funding, and buying names are all scriptable. See
+  [Agents and CI](/build/testnet/funds-and-faucet#agents-and-ci).
+</Callout>
+
+## Skills and integrations
+
+Several ar.io repositories ship [Agent Skills](https://code.claude.com/docs/en/skills) you can use
+directly:
+
+- **ARIO Deploy** — deploy apps to the permaweb and update ArNS from your editor. See
+  [what the skill does](/sdks/ario-deploy/what-the-skill-does) and
+  [add it to your project](/sdks/ario-deploy/add-the-skill-to-your-project).
+- **`ar-io-gateway-operator`** — operating an ar.io node: health, indexing lag, ArNS resolution,
+  data retrieval, and common pitfalls. Ships in the
+  [ar-io-node](https://github.com/ar-io/ar-io-node) repo under `.claude/skills/`.
+- **`ario-testnet-faucet`** — the faucet claim API and flow, for agents working against the
+  [Testnet Sandbox](/build/testnet). Ships in the `ar-io-faucet` repo.
+
+<Callout type="info">
+  `/SKILL.md` above is itself a conformant Agent Skill — it carries `name` and `description`
+  frontmatter, so you can drop it straight into a project as `.claude/skills/ario/SKILL.md`.
+</Callout>
+
+## Tools built into these docs
+
+Every page carries agent-friendly affordances:
+
+- **Open in AI** — send the current page straight to ChatGPT, Claude, Scira, or T3 Chat.
+- **Copy as Markdown** — grab the raw source of any page for pasting into a prompt.
+- **Ask Arie** — an in-docs AI assistant that answers from this documentation with citations.
+
+## Pointing an agent at ar.io
+
+<Steps>
+
+<Step>
+### Load the index
+
+Fetch <a href="/llms.txt" target="_blank" rel="noopener noreferrer">`https://docs.ar.io/llms.txt`</a>
+so the agent knows what's available and where.
+</Step>
+
+<Step>
+### Load the skill for code generation
+
+Fetch <a href="/SKILL.md" target="_blank" rel="noopener noreferrer">`https://docs.ar.io/SKILL.md`</a>
+for known-good patterns, constants, and URL conventions.
+</Step>
+
+<Step>
+### Narrow to an SDK
+
+Pull the relevant `llm.txt` (table above) instead of the full corpus — smaller context, better
+answers.
+</Step>
+
+<Step>
+### Run against the sandbox
+
+Build and test on the [Testnet Sandbox](/build/testnet) before touching mainnet.
+</Step>
+
+</Steps>
+
+## Related
+
+<Cards>
+  <Card
+    title="Testnet Sandbox"
+    description="Free Solana devnet environment — the safe place for agents to run"
+    href="/build/testnet"
+  />
+  <Card
+    title="ar.io SDK"
+    description="TypeScript SDK for ArNS, gateways, and Solana program operations"
+    href="/sdks/ar-io-sdk"
+  />
+  <Card
+    title="Gateway API Reference"
+    description="HTTP endpoints for data retrieval and ArNS resolution"
+    href="/apis"
+  />
+  <Card
+    title="Get Help"
+    description="Ask in the ar.io Discord"
+    href="https://discord.com/invite/HGG52EtTc2"
+  />
+</Cards>

--- a/content/build/agents.mdx
+++ b/content/build/agents.mdx
@@ -7,7 +7,6 @@ keywords:
   - llms.txt
   - SKILL.md
   - llm.txt
-  - MCP
   - Claude
   - agent skill
 ---
@@ -58,7 +57,7 @@ Each SDK ships its own flattened reference, which is much cheaper to load than t
 
 ## Give your agent somewhere safe to run
 
-Agents learn fastest by *doing*, but you don't want a agent spending real money or writing
+Agents learn fastest by *doing*, but you don't want an agent spending real money or writing
 permanent data while it figures things out. The **[Testnet Sandbox](/build/testnet)** is built for
 exactly this:
 
@@ -75,15 +74,16 @@ exactly this:
 
 ## Skills and integrations
 
-Several ar.io repositories ship [Agent Skills](https://code.claude.com/docs/en/skills) you can use
-directly:
+Several ar.io repositories ship agent tooling:
 
-- **ARIO Deploy** — deploy apps to the permaweb and update ArNS from your editor. See
+- **ARIO Deploy** — a Claude Code skill for deploying apps to the permaweb and updating ArNS. See
   [what the skill does](/sdks/ario-deploy/what-the-skill-does) and
-  [add it to your project](/sdks/ario-deploy/add-the-skill-to-your-project).
-- **`ar-io-gateway-operator`** — operating an ar.io node: health, indexing lag, ArNS resolution,
-  data retrieval, and common pitfalls. Ships in the
-  [ar-io-node](https://github.com/ar-io/ar-io-node) repo under `.claude/skills/`.
+  [add it to your project](/sdks/ario-deploy/add-the-skill-to-your-project) for setup.
+- **`ar-io-gateway-operator`** — a conformant
+  [Agent Skill](https://code.claude.com/docs/en/skills) for operating an ar.io node: health,
+  indexing lag, ArNS resolution, data retrieval, and common pitfalls. Ships in the
+  [ar-io-node](https://github.com/ar-io/ar-io-node) repo under
+  `.claude/skills/ar-io-gateway-operator/`.
 - **`ario-testnet-faucet`** — the faucet claim API and flow, for agents working against the
   [Testnet Sandbox](/build/testnet). Ships in the `ar-io-faucet` repo.
 

--- a/content/build/index.mdx
+++ b/content/build/index.mdx
@@ -4,7 +4,7 @@ description: "Developer documentation and resources for building on the ar.io ec
 icon: Wrench
 ---
 
-import { Code, Zap, BookOpen, Rocket, Network, Database, ShieldCheck, FlaskConical } from "lucide-react";
+import { Code, Zap, BookOpen, Rocket, Network, Database, ShieldCheck, FlaskConical, Cpu } from "lucide-react";
 import Image from "next/image";
 
 Welcome to ar.io's developer documentation.
@@ -39,6 +39,12 @@ If you're unfamiliar with Arweave's permanent storage and ar.io we recommend rea
     title="Testnet Sandbox"
     description="Try the full stack — upload, pay, buy ArNS names, and serve data — free on Solana devnet, no mainnet"
     href="/build/testnet"
+  />
+  <Card
+    icon={<Cpu />}
+    title="AI Agents & LLMs"
+    description="Machine-readable docs — llms.txt, SKILL.md, and per-SDK llm.txt — for building with AI coding agents"
+    href="/build/agents"
   />
 </Cards>
 

--- a/content/build/meta.json
+++ b/content/build/meta.json
@@ -7,6 +7,7 @@
     "index",
     "introduction",
     "testnet",
+    "agents",
     "upload",
     "access",
     "run-a-gateway",

--- a/content/build/testnet/index.mdx
+++ b/content/build/testnet/index.mdx
@@ -70,9 +70,9 @@ permanent data. See [building with an agent](#building-with-an-agent) below.
 path and x402 use **Base Sepolia**.
 
 <Callout type="info">
-  These are shared sandbox endpoints, distinct from ArDrive's dev bundler
-  (`*.ardrive.dev`). Point your app at `*.services.ar-io.dev` to exercise the full **ar.io**
-  stack — upload, payment, ArNS, and gateway — together.
+  Point your app at `*.services.ar-io.dev` and `ar-io.dev` to exercise the full **ar.io** stack —
+  upload, payment, ArNS, and gateway — together. These are shared sandbox endpoints, so treat them
+  as a testbed rather than a production plane.
 </Callout>
 
 ## Quick start

--- a/content/learn/(introduction)/index.mdx
+++ b/content/learn/(introduction)/index.mdx
@@ -21,9 +21,10 @@ import {
 Ar.io is a data infrastructure solution for long-term access. We help enterprises, institutions, and platforms ensure that critical information remains accessible, verifiable, and intact over time — even as systems, providers, technologies, or attacks disrupt the environments around them.
 
 <Callout type="info">
-  **For AI and LLM users**: Access the complete documentation in plain text
-  format at [llms-full.txt](/llms-full.txt) for easy consumption by AI agents
-  and language models.
+  **For AI and LLM users**: Start at <a href="/llms.txt" target="_blank" rel="noopener noreferrer">llms.txt</a> for
+  a machine-readable index, <a href="/SKILL.md" target="_blank" rel="noopener noreferrer">SKILL.md</a> for
+  code-generation recipes, or <a href="/llms-full.txt" target="_blank" rel="noopener noreferrer">llms-full.txt</a> for
+  the complete documentation as plain text. See [AI Agents & LLMs](/build/agents) for the full toolkit.
 </Callout>
 
 ## Explore the Documentation

--- a/content/sdks/ar-io-sdk/index.mdx
+++ b/content/sdks/ar-io-sdk/index.mdx
@@ -8,6 +8,13 @@ import { BookOpen, Code, Settings, Network, Server, Coins } from "lucide-react";
 import { Steps, Step } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
+<Callout type="info">
+  **For AI and LLM users**: Access the complete ar.io SDK documentation in plain text format at{" "}
+  <a href="/sdks/ar-io-sdk/llm.txt" target="_blank" rel="noopener noreferrer">llm.txt</a> for easy
+  consumption by AI agents and language models. See [AI Agents & LLMs](/build/agents) for the full
+  agent toolkit.
+</Callout>
+
 The ar.io SDK provides comprehensive tools for interacting with ar.io and the Arweave ecosystem. Built with TypeScript, it offers type-safe interfaces for ArNS name management, gateway operations, and Solana program interactions. The SDK defaults to the Solana backend as of v3.23.
 
 ## Quick Start

--- a/content/sdks/turbo-sdk/index.mdx
+++ b/content/sdks/turbo-sdk/index.mdx
@@ -8,6 +8,13 @@ import { BookOpen, Code, Upload, Zap, CreditCard, Settings } from "lucide-react"
 import { Steps, Step } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
+<Callout type="info">
+  **For AI and LLM users**: Access the complete Turbo SDK documentation in plain text format at{" "}
+  <a href="/sdks/turbo-sdk/llm.txt" target="_blank" rel="noopener noreferrer">llm.txt</a> for easy
+  consumption by AI agents and language models. See [AI Agents & LLMs](/build/agents) for the full
+  agent toolkit.
+</Callout>
+
 The Turbo SDK provides a high-level interface for uploading data to Arweave through Turbo's optimized infrastructure. Built with TypeScript, it offers seamless integration with built-in error handling, automatic retries, and transparent pricing.
 
 ## Quick Start

--- a/content/sdks/wayfinder/index.mdx
+++ b/content/sdks/wayfinder/index.mdx
@@ -9,6 +9,13 @@ import { Card, Cards } from "fumadocs-ui/components/card";
 import { Callout } from "fumadocs-ui/components/callout";
 import { BookOpen, Network, Server, Globe, Terminal, Chrome, Router } from "lucide-react";
 
+<Callout type="info">
+  **For AI and LLM users**: Access the complete Wayfinder documentation in plain text format at{" "}
+  <a href="/sdks/wayfinder/llm.txt" target="_blank" rel="noopener noreferrer">llm.txt</a> for easy
+  consumption by AI agents and language models. See [AI Agents & LLMs](/build/agents) for the full
+  agent toolkit.
+</Callout>
+
 Wayfinder leverages the decentralized ar.io Network to provide robust, censorship-resistant access to data stored on Arweave, removing reliance on centralized gateways. By routing requests through a distributed set of community-operated gateways, Wayfinder ensures high availability, redundancy, and improved performance for users and applications.
 
 The `ar://` protocol enables decentralized resolution and access to Arweave data using several flexible URL formats:

--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: ario-developer
+description: Build applications on ar.io and Arweave — permanent storage via Turbo, ArNS naming, gateway data access, and Solana-based protocol operations. Use whenever the user asks about uploading or storing data permanently, registering or resolving ArNS names, ANTs, undernames, Turbo credits, fetching data from ar.io gateways, the @ar.io/sdk, @ardrive/turbo-sdk, or wayfinder — including "deploy my site permanently", "buy a name", "point a name at my upload", or testing against the ar.io testnet sandbox.
+---
+
 # ar.io Developer Skill — AI Agent Reference
 
 This file gives AI coding agents the knowledge to build applications on ar.io and Arweave. It covers the full stack: permanent storage, naming, gateways, and SDKs.
@@ -295,11 +300,51 @@ Actual price = Base Fee x Demand Factor. Use `ario.getTokenCost()` to check live
 `TurboFactory.authenticated({ privateKey, token })` or `TurboFactory.unauthenticated()`
 `upload({ data, dataItemOpts? })`, `uploadFile({ fileStreamFactory, fileSizeFactory, dataItemOpts? })`, `uploadFolder({ folderPath, dataItemOpts?, manifestOptions? })`, `getBalance()`, `getUploadCosts({ bytes: [size] })`, `topUpWithTokens({ tokenAmount })`, `shareCredits({ approvedAddress, approvedWincAmount })`, `revokeCredits({ approvedAddress })`
 
+## Testnet Sandbox (test without spending real value)
+
+Build and test the full stack — upload, payment, ArNS, and gateway — on **Solana devnet** with a
+faucet-funded staging ARIO token. Nothing costs real money and nothing is permanent.
+
+| Service | URL |
+|---|---|
+| Upload API | `https://upload.services.ar-io.dev` |
+| Payment API | `https://payment.services.ar-io.dev` |
+| Gateway (serve / resolve / GraphQL) | `https://ar-io.dev` |
+| ARIO faucet | `https://faucet.services.ar-io.dev` |
+
+Staging ARIO mint: `6vTw5CysRXQ4ybbHkDUiisHWVsBeMtUzYvJqs2iqHyaN` (Solana devnet, 6 decimals).
+
+```typescript
+// Turbo SDK against the sandbox (Solana devnet signer)
+const turbo = TurboFactory.authenticated({
+  signer,
+  token: 'solana',
+  gatewayUrl: 'https://api.devnet.solana.com', // Solana RPC to verify funding txs — NOT the ar.io gateway
+  uploadServiceConfig:  { url: 'https://upload.services.ar-io.dev' },
+  paymentServiceConfig: { url: 'https://payment.services.ar-io.dev' },
+});
+// Read bytes back from the gateway: https://ar-io.dev/raw/<id>
+```
+
+Rules that will bite you:
+- **Data is ephemeral** — purged after ~3 days, never posted to mainnet Arweave.
+- `x-ar-io-verified: false` on sandbox data is **expected**, not an error.
+- Uploads are free up to **105 KiB/item** (10 MiB lifetime per wallet and per IP); max item **10 MiB**.
+- ArNS names bought **through the bundler** must be **≥ 8 characters**; buying directly via
+  `@ar.io/sdk` has no such floor.
+- Only testnet funding tokens are accepted (`ario`, `solana`, `base-eth`); mainnet tokens are rejected.
+- **The faucet needs a human once** — its GitHub OAuth can't be completed headlessly. Have a person
+  claim to the agent's wallet, then everything else is scriptable.
+
+Full guide: https://docs.ar.io/build/testnet
+
 ## Documentation
 
 Full docs: https://docs.ar.io
+- Agent entry points (llms.txt, SKILL.md, per-SDK llm.txt): https://docs.ar.io/build/agents
 - SDK reference: https://docs.ar.io/sdks/ar-io-sdk
 - Turbo SDK: https://docs.ar.io/sdks/turbo-sdk
 - Gateway API: https://docs.ar.io/apis/ar-io-node
 - ArNS guide: https://docs.ar.io/learn/arns
 - Wayfinder: https://docs.ar.io/sdks/wayfinder
+- Testnet sandbox: https://docs.ar.io/build/testnet

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -3058,6 +3058,113 @@ qj2yubvbk4yjv24syelk24wqivcbaqpbmg7yxfof5mdqlrh4rova
 
 View the full code for generating browser sandbox values [here](https://github.com/ar-io/arweave-gateway/blob/719f43f8d6135adf44c87701e95f58105638710a/src/gateway/middleware/sandbox.ts#L69).
 
+# AI Agents & LLMs (/build/agents)
+
+These docs are built to be consumed by **AI coding agents**, not just read by humans. Everything
+below is a plain-text file you can fetch, paste, or point an agent at — no scraping required.
+
+  **Fastest path:** point your agent at `https://docs.ar.io/llms.txt`.
+  It's a short index that links everything else, following the
+  [llmstxt.org](https://llmstxt.org) convention agents already look for.
+
+## Machine-readable entry points
+
+| File | What it is | Reach for it when |
+|---|---|---|
+| `/llms.txt` | A short **index** of the documentation with links and quick facts | Discovery — the entry point |
+| `/SKILL.md` | A **procedural agent skill**: SDK patterns, code recipes, URL conventions, constants | Generating working code |
+| `/llms-full.txt` | The **entire docs corpus** as one plain-text file (~1.2 MB) | Deep context, or RAG ingestion |
+| `/sdks//llm.txt` | **Per-SDK reference** text (see table below) | Working inside a single SDK |
+
+### `llm.txt` vs `SKILL.md` — what's the difference?
+
+They solve different problems and are meant to be used together:
+
+- **`llms.txt` / `llms-full.txt` / `llm.txt` are *reference*.** They're documentation flattened to
+  plain text so a model has the facts in context. Passive — they describe *what exists*.
+- **`SKILL.md` is *procedural*.** It follows the
+  [Agent Skills](https://code.claude.com/docs/en/skills) convention: task-oriented instructions,
+  known-good code recipes, and constants that teach an agent *how to actually build* on ar.io —
+  which SDK call to make, the correct ArNS URL shape, what to avoid.
+
+A useful rule of thumb: load **`SKILL.md`** when the agent needs to *write code*, and
+**`llms-full.txt`** when it needs to *answer questions* about the wider platform.
+
+## Per-SDK reference text
+
+Each SDK ships its own flattened reference, which is much cheaper to load than the full corpus:
+
+| SDK | Plain text |
+|---|---|
+| ar.io SDK | `/sdks/ar-io-sdk/llm.txt` |
+| Turbo SDK | `/sdks/turbo-sdk/llm.txt` |
+| Wayfinder | `/sdks/wayfinder/llm.txt` |
+| ArDrive Core JS | `/sdks/ardrive-core-js/llm.txt` |
+| CLIs (ArDrive CLI, ARIO Deploy) | `/sdks/(clis)/llm.txt` |
+
+## Give your agent somewhere safe to run
+
+Agents learn fastest by *doing*, but you don't want a agent spending real money or writing
+permanent data while it figures things out. The **[Testnet Sandbox](/build/testnet)** is built for
+exactly this:
+
+- Runs the **full ar.io stack** — upload, payment, ArNS, and gateway — on Solana **devnet**.
+- Funded by a **faucet**, so there's no real value at risk.
+- **Nothing is permanent**: data is purged after ~3 days and never reaches mainnet Arweave.
+
+  **One step needs a human.** The ARIO faucet is GitHub-gated and its OAuth consent can't be
+  completed headlessly. Have a person claim once to the wallet your agent will use — after that,
+  uploading, funding, and buying names are all scriptable. See
+  [Agents and CI](/build/testnet/funds-and-faucet#agents-and-ci).
+
+## Skills and integrations
+
+Several ar.io repositories ship [Agent Skills](https://code.claude.com/docs/en/skills) you can use
+directly:
+
+- **ARIO Deploy** — deploy apps to the permaweb and update ArNS from your editor. See
+  [what the skill does](/sdks/ario-deploy/what-the-skill-does) and
+  [add it to your project](/sdks/ario-deploy/add-the-skill-to-your-project).
+- **`ar-io-gateway-operator`** — operating an ar.io node: health, indexing lag, ArNS resolution,
+  data retrieval, and common pitfalls. Ships in the
+  [ar-io-node](https://github.com/ar-io/ar-io-node) repo under `.claude/skills/`.
+- **`ario-testnet-faucet`** — the faucet claim API and flow, for agents working against the
+  [Testnet Sandbox](/build/testnet). Ships in the `ar-io-faucet` repo.
+
+  `/SKILL.md` above is itself a conformant Agent Skill — it carries `name` and `description`
+  frontmatter, so you can drop it straight into a project as `.claude/skills/ario/SKILL.md`.
+
+## Tools built into these docs
+
+Every page carries agent-friendly affordances:
+
+- **Open in AI** — send the current page straight to ChatGPT, Claude, Scira, or T3 Chat.
+- **Copy as Markdown** — grab the raw source of any page for pasting into a prompt.
+- **Ask Arie** — an in-docs AI assistant that answers from this documentation with citations.
+
+## Pointing an agent at ar.io
+
+### Load the index
+
+Fetch `https://docs.ar.io/llms.txt`
+so the agent knows what's available and where.
+
+### Load the skill for code generation
+
+Fetch `https://docs.ar.io/SKILL.md`
+for known-good patterns, constants, and URL conventions.
+
+### Narrow to an SDK
+
+Pull the relevant `llm.txt` (table above) instead of the full corpus — smaller context, better
+answers.
+
+### Run against the sandbox
+
+Build and test on the [Testnet Sandbox](/build/testnet) before touching mainnet.
+
+## Related
+
 # Bundler (/build/extensions/bundler)
 
 ## Overview
@@ -10986,6 +11093,11 @@ If you're unfamiliar with Arweave's permanent storage and ar.io we recommend rea
     description="Try the full stack — upload, pay, buy ArNS names, and serve data — free on Solana devnet, no mainnet"
     href="/build/testnet"
   />
+  }
+    title="AI Agents & LLMs"
+    description="Machine-readable docs — llms.txt, SKILL.md, and per-SDK llm.txt — for building with AI coding agents"
+    href="/build/agents"
+  />
 
 ## Developer Resources
 
@@ -17765,9 +17877,9 @@ From there, everything is a scriptable API call — uploading, funding credits, 
 ArNS names all work without any browser interaction. Re-claim (again by a human) when the balance
 runs low.
 
-  The faucet ships an `ario-testnet-faucet` agent skill documenting the claim API and flow. Pair
-  it with the human-claims-once pattern above so your agent has funds without needing to solve the
-  OAuth gate.
+  **Faucet agent skill.** The faucet ships an `ario-testnet-faucet` agent skill documenting the
+  claim API and flow. Pair it with the human-claims-once pattern above so your agent has funds
+  without needing to solve the OAuth gate.
 
 ## Next steps
 
@@ -17824,9 +17936,9 @@ permanent data. See [building with an agent](#building-with-an-agent) below.
 `6vTw5CysRXQ4ybbHkDUiisHWVsBeMtUzYvJqs2iqHyaN` (6 decimals). The optional `base-eth` funding
 path and x402 use **Base Sepolia**.
 
-  These are shared sandbox endpoints, distinct from ArDrive's dev bundler
-  (`*.ardrive.dev`). Point your app at `*.services.ar-io.dev` to exercise the full **ar.io**
-  stack — upload, payment, ArNS, and gateway — together.
+  Point your app at `*.services.ar-io.dev` and `ar-io.dev` to exercise the full **ar.io** stack —
+  upload, payment, ArNS, and gateway — together. These are shared sandbox endpoints, so treat them
+  as a testbed rather than a production plane.
 
 ## Quick start
 
@@ -17874,10 +17986,10 @@ Your name is live at `https://.ar-io.dev`. See
 The sandbox is a natural fit for AI coding assistants and automated tests — free tokens, plain
 HTTP endpoints, and no way to spend real value or write permanent data.
 
-  The ARIO faucet is **GitHub-gated** to prevent abuse, and the OAuth consent can't be
-  completed headlessly. The standard pattern is: a **human claims once** to the wallet address
-  your agent will use, then the agent simply **uses** the ARIO. After that, uploading, funding,
-  and buying ArNS names are all scriptable API calls. See
+  **One human step: the faucet.** The ARIO faucet is **GitHub-gated** to prevent abuse, and the
+  OAuth consent can't be completed headlessly. The standard pattern is: a **human claims once** to
+  the wallet address your agent will use, then the agent simply **uses** the ARIO. After that,
+  uploading, funding, and buying ArNS names are all scriptable API calls. See
   [Funds & Faucet → Agents and CI](/build/testnet/funds-and-faucet#agents-and-ci).
 
 This documentation is also available as machine-readable text (`/llms-full.txt`) and every page
@@ -20791,9 +20903,10 @@ import {
 
 Ar.io is a data infrastructure solution for long-term access. We help enterprises, institutions, and platforms ensure that critical information remains accessible, verifiable, and intact over time — even as systems, providers, technologies, or attacks disrupt the environments around them.
 
-  **For AI and LLM users**: Access the complete documentation in plain text
-  format at [llms-full.txt](/llms-full.txt) for easy consumption by AI agents
-  and language models.
+  **For AI and LLM users**: Start at llms.txt for
+  a machine-readable index, SKILL.md for
+  code-generation recipes, or llms-full.txt for
+  the complete documentation as plain text. See [AI Agents & LLMs](/build/agents) for the full toolkit.
 
 ## Explore the Documentation
 
@@ -28593,6 +28706,11 @@ flow and the cross-language canonical-message vectors.
 
 # ar.io SDK (/sdks/ar-io-sdk)
 
+**For AI and LLM users**: Access the complete ar.io SDK documentation in plain text format at{" "}
+  llm.txt for easy
+  consumption by AI agents and language models. See [AI Agents & LLMs](/build/agents) for the full
+  agent toolkit.
+
 The ar.io SDK provides comprehensive tools for interacting with ar.io and the Arweave ecosystem. Built with TypeScript, it offers type-safe interfaces for ArNS name management, gateway operations, and Solana program interactions. The SDK defaults to the Solana backend as of v3.23.
 
 ## Quick Start
@@ -30537,6 +30655,11 @@ const turbo = TurboFactory.authenticated({
 
 # Turbo SDK (/sdks/turbo-sdk)
 
+**For AI and LLM users**: Access the complete Turbo SDK documentation in plain text format at{" "}
+  llm.txt for easy
+  consumption by AI agents and language models. See [AI Agents & LLMs](/build/agents) for the full
+  agent toolkit.
+
 The Turbo SDK provides a high-level interface for uploading data to Arweave through Turbo's optimized infrastructure. Built with TypeScript, it offers seamless integration with built-in error handling, automatic retries, and transparent pricing.
 
 ## Quick Start
@@ -30751,6 +30874,11 @@ The Turbo CLI provides the following commands to manage Credit Share Approvals:
 - `--use-signer-balance-first`: Use the signer's balance first before using Credit Share Approvals.
 
 # Wayfinder SDK's (/sdks/wayfinder)
+
+**For AI and LLM users**: Access the complete Wayfinder documentation in plain text format at{" "}
+  llm.txt for easy
+  consumption by AI agents and language models. See [AI Agents & LLMs](/build/agents) for the full
+  agent toolkit.
 
 Wayfinder leverages the decentralized ar.io Network to provide robust, censorship-resistant access to data stored on Arweave, removing reliance on centralized gateways. By routing requests through a distributed set of community-operated gateways, Wayfinder ensures high availability, redundancy, and improved performance for users and applications.
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -3104,7 +3104,7 @@ Each SDK ships its own flattened reference, which is much cheaper to load than t
 
 ## Give your agent somewhere safe to run
 
-Agents learn fastest by *doing*, but you don't want a agent spending real money or writing
+Agents learn fastest by *doing*, but you don't want an agent spending real money or writing
 permanent data while it figures things out. The **[Testnet Sandbox](/build/testnet)** is built for
 exactly this:
 
@@ -3119,15 +3119,16 @@ exactly this:
 
 ## Skills and integrations
 
-Several ar.io repositories ship [Agent Skills](https://code.claude.com/docs/en/skills) you can use
-directly:
+Several ar.io repositories ship agent tooling:
 
-- **ARIO Deploy** — deploy apps to the permaweb and update ArNS from your editor. See
+- **ARIO Deploy** — a Claude Code skill for deploying apps to the permaweb and updating ArNS. See
   [what the skill does](/sdks/ario-deploy/what-the-skill-does) and
-  [add it to your project](/sdks/ario-deploy/add-the-skill-to-your-project).
-- **`ar-io-gateway-operator`** — operating an ar.io node: health, indexing lag, ArNS resolution,
-  data retrieval, and common pitfalls. Ships in the
-  [ar-io-node](https://github.com/ar-io/ar-io-node) repo under `.claude/skills/`.
+  [add it to your project](/sdks/ario-deploy/add-the-skill-to-your-project) for setup.
+- **`ar-io-gateway-operator`** — a conformant
+  [Agent Skill](https://code.claude.com/docs/en/skills) for operating an ar.io node: health,
+  indexing lag, ArNS resolution, data retrieval, and common pitfalls. Ships in the
+  [ar-io-node](https://github.com/ar-io/ar-io-node) repo under
+  `.claude/skills/ar-io-gateway-operator/`.
 - **`ario-testnet-faucet`** — the faucet claim API and flow, for agents working against the
   [Testnet Sandbox](/build/testnet). Ships in the `ar-io-faucet` repo.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,6 +6,8 @@
 
 - [SKILL.md (structured agent reference)](/SKILL.md): Concise SDK patterns, code recipes, ArNS URL conventions, constants, and API reference for building on ar.io. Start here for code generation.
 - [Full documentation text](/llms-full.txt): Complete content from all documentation pages for deep context.
+- [AI agents & LLMs guide](/build/agents): All machine-readable entry points, how they differ, and how to point an agent at ar.io.
+- [Testnet sandbox](/build/testnet): Free Solana devnet environment (upload, payment, ArNS, gateway) for testing without real money or permanent data.
 - [ar.io SDK reference](/sdks/ar-io-sdk): TypeScript SDK for ArNS names, gateways, staking.
 - [Turbo SDK reference](/sdks/turbo-sdk): Upload files and folders to Arweave.
 - [Wayfinder SDK reference](/sdks/wayfinder): Decentralized data fetching with verification.
@@ -13,12 +15,20 @@
 - [ArNS naming system](/learn/arns): Human-readable names for permanent data.
 - [For Solana developers](/learn/solana-developers): Quick-start guide mapping Solana concepts to ar.io.
 
+## Per-SDK plain text
+
+- [/sdks/ar-io-sdk/llm.txt](/sdks/ar-io-sdk/llm.txt): ar.io SDK reference only.
+- [/sdks/turbo-sdk/llm.txt](/sdks/turbo-sdk/llm.txt): Turbo SDK reference only.
+- [/sdks/wayfinder/llm.txt](/sdks/wayfinder/llm.txt): Wayfinder reference only.
+- [/sdks/ardrive-core-js/llm.txt](/sdks/ardrive-core-js/llm.txt): ArDrive Core JS reference only.
+
 ## Quick Facts
 
 - ARIO is an SPL Token on Solana (6 decimals)
 - ANTs (Ar.io Name Tokens) are Metaplex Core NFTs
-- ArNS names resolve as subdomains: `yourname.arweave.net`
-- Undernames use underscores: `docs_yourname.arweave.net`
+- ArNS names resolve as subdomains on every gateway: `yourname.ar.io`
+- Undernames use underscores, not dots: `docs_yourname.ar.io`
 - SDK: `npm install @ar.io/sdk @solana/kit`
 - Turbo: `npm install @ardrive/turbo-sdk`
 - Files under 100 KiB upload free via Turbo
+- Test for free on Solana devnet at `https://ar-io.dev` (see the testnet sandbox above)


### PR DESCRIPTION
## Why

The docs already shipped a strong agentic surface — `llms.txt`, `SKILL.md`, `llms-full.txt`, and five per-SDK `llm.txt` files — but almost **none of it was reachable from the site**, and parts had drifted out of sync. An agent could find `/llms.txt` by convention; a human never would.

Three concrete problems:

1. **Nothing in `content/` or `src/` linked `SKILL.md` or `llms.txt`.** Zero references.
2. **Three of five per-SDK `llm.txt` files were orphaned** — `ar-io-sdk`, `turbo-sdk`, and `wayfinder` generate an `llm.txt` that nothing linked. Only `ardrive-core-js` and `ardrive-cli` had callouts.
3. **`llms.txt` had stale ArNS examples** (`yourname.arweave.net`) contradicting the standardized `yourname.ar.io` convention already used in `SKILL.md` and the docs.

## What changed

**New `/build/agents` hub** — one place listing every machine-readable entry point, and explaining the distinction that kept coming up:

- `llms.txt` / `llms-full.txt` / `llm.txt` are **reference** — passive, they describe *what exists*.
- `SKILL.md` is **procedural** — task-oriented recipes that teach an agent *how to build*.

It also covers pointing an agent at ar.io, the available Agent Skills, and the Testnet Sandbox as the safe place for agents to run.

**Linked the orphaned `llm.txt` files.** Worth noting: `generate-sdk-docs.ts` deliberately preserves `index.mdx` across regeneration (reads it, wipes the dir, restores it), so these callouts persist — no generator change needed.

**Made `public/SKILL.md` a conformant Agent Skill.** Added `name`/`description` frontmatter so it can be dropped into a project as `.claude/skills/ario/SKILL.md`. Also gave it the Testnet Sandbox knowledge it completely lacked — endpoints, staging mint, free-tier limits, the 8-char bundler rule, and the faucet's one required human step.

**Fixed `llms.txt`** — corrected the ArNS examples and indexed the agents page, testnet sandbox, and per-SDK `llm.txt` files.

**Surfaced the entry points** from the Learn intro and Build landing, and dropped a stale `ardrive.dev` reference from the testnet overview.

## Verification

- `eslint` clean on all changed MDX.
- `check-links`: **8 → 7** errors. All 7 remaining are pre-existing — 6 in generated SDK docs (need upstream README fixes) and 1 missing guide page (`crossmint-nft-minting-app`). None from this PR.
- `llms-full.txt` regenerated → 306 sections, includes the new agents page.
- `SKILL.md` frontmatter parses as valid YAML (`name`, `description`).
- All 8 referenced static assets verified to exist.

> Note: the dev server can't render locally in this environment — `node_modules` holds a Windows `lightningcss` binary while the shell is `linux-arm64`, so every page 500s including untouched ones. Validation was done via lint + link-check + asset/YAML verification instead.

## Follow-ups: upstream README patches (not in this PR)

`ardrive.dev` **is** `ar-io.dev` (the ar.io testnet), with `upload.services.ar-io.dev` / `payment.services.ar-io.dev`. The remaining `ardrive.dev` references live in **generated** pages, so they can only be fixed upstream. Both patches below were verified with `git apply --check`.

### 1. `ardriveapp/turbo-sdk` (branch `alpha`)

Repoints all 7 `ardrive.dev` references to the ar.io testnet, **fixes a real missing-brace syntax bug** in the Ethereum Sepolia example, and adds a sandbox note. Fixes `content/sdks/turbo-sdk/(apis)/turbofactory.mdx`.

```diff
-    url: 'https://payment.ardrive.dev', // Dev payment service
+    url: 'https://payment.services.ar-io.dev', // ar.io testnet sandbox
-    url: 'https://upload.ardrive.dev', // Dev upload service
+    url: 'https://upload.services.ar-io.dev', // ar.io testnet sandbox
   (... same for the Solana Devnet and Ethereum Sepolia examples ...)

   uploadServiceConfig: {
     url: 'https://upload.services.ar-io.dev',
-
+  },
 });

-- `yarn test` - runs integration tests against dev environment (e.g. `https://payment.ardrive.dev` and `https://upload.ardrive.dev`)
+- `yarn test` - runs integration tests against dev environment (e.g. `https://payment.services.ar-io.dev` and `https://upload.services.ar-io.dev`)
```

Also adds ARIO staging to the supported-testnet list:

```diff
 **Supported Testnets**:
 
+- **ARIO staging** (`ario`) - Staging ARIO on Solana devnet; fee-free funding, claim from the [ar.io faucet](https://faucet.services.ar-io.dev)
 - **Base Sepolia** (`base-eth`) - Supports on-demand funding
 - **Solana Devnet** (`solana`) - Supports on-demand funding
```

Plus a short paragraph after the code block noting these are the ar.io Testnet Sandbox, that data is served from `https://ar-io.dev`, and that it is ephemeral (~3 days, never mainnet).

> [!WARNING]
> The Ethereum Sepolia (`ethereum`) and Polygon Amoy (`pol`) examples were **kept**, but the sandbox's current `ACCEPTED_FUNDING_TOKENS` is `ario,solana,base-eth` — those two will return `Token not supported` until testnet support is added.

### 2. `ar-io/ar-io-deploy` (branch `main`) — ours, can merge immediately

Fixes `content/sdks/(clis)/ario-deploy/bundler-service.mdx`:

```diff
-| **Development / staging** | `https://upload.ardrive.dev`                            |
+| **Development / staging** | `https://upload.services.ar-io.dev`                     |
```

### 3. `ar-io/ar-io-sdk` (branch `alpha`) — ArNS naming

```diff
-### Arweave Name System (ArNS)
+### ar.io Name System (ArNS)
```

This is the last "Arweave Name System" in the docs (everywhere else says "Ar.io Name System").

> [!WARNING]
> This moves the generated slug `arweave-name-system-arns` → `ar-io-name-system-arns`, so it needs a `redirects.mjs` entry plus updating the link in `build/access/arns.mdx:53`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUArqiyP9GbfJrqNFVkUBr
